### PR TITLE
Make process more efficient

### DIFF
--- a/commands/balance.js
+++ b/commands/balance.js
@@ -24,29 +24,19 @@ module.exports = {
     //The person executing the command has a registered address
     if (users['addresses'][message.author.id] != undefined)
     {
-			//For some reason algorand sdk doesn't provide a method to get the ASA balance of a certain address :/
-			//Instead, get balances of all the addresses and loop through
 	    console.log("g$balance Address exists")
-      coup = await algorandUtil.getAssetBalances(coupId, indexerClient)
-			sleep(waitTimeInMs)
-			eure = await algorandUtil.getAssetBalances(eureId, indexerClient)
-			sleep(waitTimeInMs)
-			swee = await algorandUtil.getAssetBalances(sweeId, indexerClient)
-			sleep(waitTimeInMs)
-			haas = await algorandUtil.getAssetBalances(haasId, indexerClient)
-	    		console.log("Got lists of ASA balances")
+		address = users['addresses'][message.author.id]
 
-			address = users['addresses'][message.author.id]
-
-			//Function that loops through to get the actual balance of an address
-			//DRY blah blah blah..... there's no point in DRYing this, it works fine already and performance gains are minimal
-			coupBal = algorandUtil.getAddressASABalance(address, coup)
-			eureBal = algorandUtil.getAddressASABalance(address, eure)
-			sweeBal = algorandUtil.getAddressASABalance(address, swee)
-			haasBal = algorandUtil.getAddressASABalance(address, haas)
-			console.log("Got the balances")
+		assets = algorandUtil.getAddressAssets(address)
+		console.log("Got lists of ASA balances")
+		
+		coupBal = assets[coupId] ? assets[coupId] : 0;
+		eureBal = assets[eureId] ? assets[eureId] : 0;
+		sweeBal = assets[sweeId] ? assets[sweeId] : 0;
+		haasBal = assets[haasId] ? assets[haasId] : 0;
+		console.log("Got the balances")
 	    
-			message.reply(`\nCoupon(:ticket:): ${coupBal}\nEure(:lemon:): ${eureBal}\nWatermelon(:watermelon:): ${sweeBal}\nHaas (:avocado:): ${haasBal}`)
+		message.reply(`\nCoupon(:ticket:): ${coupBal}\nEure(:lemon:): ${eureBal}\nWatermelon(:watermelon:): ${sweeBal}\nHaas (:avocado:): ${haasBal}`)
     }
 
     //They haven't registered an address, tell them to do so

--- a/commands/balance.js
+++ b/commands/balance.js
@@ -27,7 +27,7 @@ module.exports = {
 	    console.log("g$balance Address exists")
 		address = users['addresses'][message.author.id]
 
-		assets = algorandUtil.getAddressAssets(address)
+		assets = await algorandUtil.getAddressAssets(address, indexerClient);
 		console.log("Got lists of ASA balances")
 		
 		coupBal = assets[coupId] ? assets[coupId] : 0;

--- a/util/algorand.js
+++ b/util/algorand.js
@@ -11,7 +11,7 @@ module.exports = {
     return optedIn;
   },
 
-  getAddressAssets: function(address) {
+  getAddressAssets: async function(address, indexerClient) {
     const assetIds = [281003266, 281003863, 281004528, 281005704];
     assets = {};
 

--- a/util/algorand.js
+++ b/util/algorand.js
@@ -11,23 +11,22 @@ module.exports = {
     return optedIn;
   },
 
-  getAssetBalances: async function (assetId, indexerClient)
-  {
-    assetBalances = await indexerClient.lookupAssetBalances(assetId, -1, 1000000000000000, true ).do();
+  getAddressAssets: function(address) {
+    const assetIds = [281003266, 281003863, 281004528, 281005704];
+    assets = {};
 
-    return assetBalances;
-  },
-
-  getAddressASABalance: function (address, balances)
-  {
-    for (var i = 0; i < balances['balances'].length; i++)
+    accountInfo = await indexerClient.lookupAccountByID(address).do();
+    if (accountInfo['account'].hasOwnProperty('assets')) 
     {
-      if (balances['balances'][i]['address'] == address)
-      {
-        return balances['balances'][i]['amount'];
-      }
+        accountInfo['account']['assets'].forEach(element => 
+        {
+            if (assetIds.includes(element['asset-id'])) 
+            {
+                assets[element['asset-id']] = element['amount'];
+            }
+        });
     }
 
-    return 0;
+    return assets;
   }
 }


### PR DESCRIPTION
There is a way to directly get asset balances. They are returned as part of the account information, this change leverages that to cut down requests that need to be made, as well as compute time.